### PR TITLE
Fixed comparison of different signs warning in readwrite_data.

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -542,7 +542,7 @@ static CURLcode readwrite_data(struct Curl_easy *data,
 #endif
 
     /* make sure not more than the max recv speed bytes downloaded at once */
-    if(data->set.max_recv_speed && data->set.max_recv_speed < buffersize) {
+    if(data->set.max_recv_speed && data->set.max_recv_speed < (curl_off_t)buffersize) {
       const curl_off_t toread = data->set.max_recv_speed -
         (data->progress.downloaded - data->progress.dl_limit_size) %
           data->set.max_recv_speed;


### PR DESCRIPTION
```
curl/lib/transfer.c:545:61: warning: comparison of integers of different signs: 'curl_off_t' (aka 'long') and 'size_t' (aka 'unsigned long') [-Wsign-compare]
     if(data->set.max_recv_speed && data->set.max_recv_speed < buffersize) {
                                    ~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~
```