### PR TITLE
SPTCH-3194: fix fail code returned if 401 Unauthorized on range request

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2953,10 +2953,16 @@ CURLcode Curl_http_firstwrite(struct Curl_easy *data,
     k->ignorebody = TRUE;
     infof(data, "Ignoring the response-body");
   }
+
   if(data->state.resume_from && !k->content_range &&
      (data->state.httpreq == HTTPREQ_GET) &&
      !k->ignorebody) {
 
+    if(!(200 <= data->info.httpcode && data->info.httpcode < 300)) {
+      /* We wanted to resume a download, but the server doesn't respond with a
+       * successful code, we don't know if the server supports byte ranges */
+      return CURLE_OK;
+    }
     if(k->size == data->state.resume_from) {
       /* The resume point is at the end of file, consider this fine even if it
          doesn't allow resume from here. */


### PR DESCRIPTION
Data range can be requested and 401 Unauthorized can be responded with a body
unrelated to the requested content, and without Content-Range header, with
unrelated Content-Length value. `curl_easy_perform()` fails with the error
`CURLE_RANGE_ERROR`. It should not fail.