### PR TITLE
SPTCH-3413: fix odd total timer reset in file_do()

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -420,8 +420,6 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
 
   *done = TRUE; /* unconditionally */
 
-  Curl_pgrsStartNow(data);
-
   if(data->state.upload)
     return file_upload(data);
 


### PR DESCRIPTION
The total timer is properly reset in `MSTATE_INIT`.
`MSTATE_CONNECT` starts with resetting the timer that is a start point for further multi states.
If file://, `MSTATE_DO` calls `file_do()` that should not reset the total timer.
Otherwise, the total time is always less than the pre-transfer and the start transfer times.